### PR TITLE
 Added Windows Subsystem for Linux (WSL) support to revelator

### DIFF
--- a/lib/flammarion/revelator.rb
+++ b/lib/flammarion/revelator.rb
@@ -100,11 +100,8 @@ module Flammarion
       resource = "http://localhost:4567/" if options[:development_mode]
       chrome_path = CHROME_PATH
       chrome_path = `cygpath -u '#{CHROME_PATH}'`.strip if RbConfig::CONFIG["host_os"] == "cygwin"
-
       return false unless File.exist?(chrome_path)
-
       Process.detach(spawn(chrome_path, %[--app=#{resource}?path=#{@window_id}&port=#{server.port}&title="#{options[:title] || "Flammarion%20Engraving"}"]))
-
     end
 
     browser :chrome do |options|

--- a/lib/flammarion/revelator.rb
+++ b/lib/flammarion/revelator.rb
@@ -73,6 +73,25 @@ module Flammarion
       false
     end
 
+    browser :chrome_wsl do |options|
+      # Check for WSL, idea from https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/util/platform.rb
+      return false unless File.file?('/proc/version') &&
+        File.open('/proc/version', &:gets).downcase.include?("microsoft")
+
+      # Convert to path in WSL
+      chrome_path = `wslpath '#{CHROME_PATH}'`.strip
+      return false unless File.exist?(chrome_path)
+
+      # Convert index.html path to Windows
+      file_path = %[#{File.absolute_path(File.join(File.dirname(__FILE__), ".."))}/html/build/index.html]
+      url = "file://#{`wslpath -m '#{file_path}'`.strip}"
+
+      cmdString = %['#{chrome_path}' --app='#{url}?port=#{server.port}&path=#{@window_id}&title="#{options[:title] || "Flammarion%20Engraving"}"']
+
+      @chrome.in, @chrome.out, @chrome.err, @chrome.thread = Open3.popen3(cmdString)
+      return true if @chrome.in
+    end
+
     browser :chrome_windows do |options|
       return false unless RbConfig::CONFIG["host_os"] =~ /cygwin|mswin|mingw/
       file_path = File.absolute_path(File.join(File.dirname(__FILE__), ".."))
@@ -81,8 +100,11 @@ module Flammarion
       resource = "http://localhost:4567/" if options[:development_mode]
       chrome_path = CHROME_PATH
       chrome_path = `cygpath -u '#{CHROME_PATH}'`.strip if RbConfig::CONFIG["host_os"] == "cygwin"
+
       return false unless File.exist?(chrome_path)
+
       Process.detach(spawn(chrome_path, %[--app=#{resource}?path=#{@window_id}&port=#{server.port}&title="#{options[:title] || "Flammarion%20Engraving"}"]))
+
     end
 
     browser :chrome do |options|

--- a/lib/flammarion/server.rb
+++ b/lib/flammarion/server.rb
@@ -17,11 +17,18 @@ module Flammarion
       sleep 0.01 while not @started
     end
 
+    def wsl_platform
+      return File.file?('/proc/version') &&
+        File.open('/proc/version', &:gets).downcase.include?("microsoft")
+    end
+
     def start_server_internal
       @port = 7870
-      @port = rand(65000 - 1024) + 1024 if Gem.win_platform?
+      @port = rand(65000 - 1024) + 1024 if Gem.win_platform? || wsl_platform
+
       begin
         @server = Rubame::Server.new("0.0.0.0", @port)
+        log "WebServer started on port #{@port}"
         while true do
           @started = true
           @server.run do |ws|
@@ -67,7 +74,7 @@ module Flammarion
     end
 
     def log(str)
-      # Kernel.puts str
+      Kernel.puts str
     end
 
     def handle_exception(e)

--- a/lib/flammarion/server.rb
+++ b/lib/flammarion/server.rb
@@ -74,7 +74,7 @@ module Flammarion
     end
 
     def log(str)
-      Kernel.puts str
+      # Kernel.puts str
     end
 
     def handle_exception(e)


### PR DESCRIPTION
I am running Ruby under Windows using WSL. To use Flammarion when running under WSL while Chrome is running on Windows I added another browser option to the Revelator. 